### PR TITLE
Beta

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -1,14 +1,15 @@
 name: Develop
 
 on:
-  pull_request:
-    branches:
-      - develop
-      - feature/**
   push:
     branches:
       - develop
+      - beta
       - feature/**
+  # pull_request:
+  #   branches:
+  #     - develop
+  #     - feature/**
 
 jobs:
   test:

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18.x
+          - 20.8.x
           - 20.x
 
     steps:

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -4,15 +4,12 @@ on:
   push:
     branches:
       - develop
-      - beta
-      - feature/**
   # pull_request:
   #   branches:
   #     - develop
-  #     - feature/**
 
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-latest
 
     strategy:
@@ -53,8 +50,66 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  release:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version:
+          - 20.x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install apt packages for headless-gl
+        run: sudo apt update && sudo apt install libxi-dev xvfb libgl1-mesa-dev
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Extract version and add tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ### Enable error handling and exit the script on pipe failures
+          set -eo pipefail
+          ### Retrieve build settings and execute a command to filter MARKETING_VERSION
+          current_version=$(jq -r '.version' package.json)
+          echo "Current version: $current_version"
+          ### If the current version is found
+          if [[ $current_version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            ### If the tag exists, delete it from both local and remote
+            git fetch --tags
+            if git tag -l | grep -q "$current_version"; then
+              echo "Tag already exists: $current_version"
+              # git tag -d "$current_version"
+              # git push origin ":refs/tags/$current_version"
+            fi
+            ### Create a new tag for the current version and push it to the remote repository
+            echo "Creating a new tag: $current_version"
+            # git tag "$current_version"
+            # git push origin "$current_version"
+          else
+            ### If the version could not be retrieved, display an error message
+            echo "Error: Could not retrieve the version."
+          fi
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm semantic-release --dry-run
+        run: |
+          pnpm semantic-release --dry-run
+    needs: tests

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -56,4 +56,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: chmod +x minify.sh && yarn run semantic-release --dry-run
+        run: pnpm semantic-release --dry-run

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -30,7 +30,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
           run_install: false
 
       - name: Install Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,50 +4,101 @@ on:
   push:
     branches:
       - main
-      # - alpha
-      # - beta
-      # - rc
 
 jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version:
+          - 20.8.x
+          - 20.x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install apt packages for headless-gl
+        run: sudo apt update && sudo apt install libxi-dev xvfb libgl1-mesa-dev
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm lint-check
+
+      - name: Test
+        run: xvfb-run --auto-servernum pnpm test-coverage
+
+      - name: Coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   release:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install apt packages for headless-gl
-        run: sudo apt update && sudo apt install libxi-dev xvfb libgl1-mesa-dev
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - name: Get Yarn cache directory
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Use Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Run eslint
-        run: yarn lint
-      - name: Run test
-        run: xvfb-run --auto-servernum yarn test:coverage
-      - name: Upload coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          cache: 'pnpm'
+
+      - name: Extract version and add tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ### Enable error handling and exit the script on pipe failures
+          set -eo pipefail
+          ### Retrieve build settings and execute a command to filter MARKETING_VERSION
+          current_version=$(jq -r '.version' package.json)
+          echo "Current version: $current_version"
+          ### If the current version is found
+          if [[ $current_version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            ### If the tag exists, delete it from both local and remote
+            git fetch --tags
+            if git tag -l | grep -q "$current_version"; then
+              git tag -d "$current_version"
+              git push origin ":refs/tags/$current_version"
+            fi
+            ### Create a new tag for the current version and push it to the remote repository
+            git tag "$current_version"
+            git push origin "$current_version"
+          else
+            ### If the version could not be retrieved, display an error message
+            echo "Error: Could not retrieve the version."
+          fi
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: chmod +x minify.sh && npm ls chalk && yarn run semantic-release
+        run: |
+          pnpm semantic-release
+    needs: tests


### PR DESCRIPTION
Add a new job to handle version tagging and release process

- Create a `release` job that runs on the latest Ubuntu version
- Set up pnpm and Node.js using a matrix strategy
- Extract the current version from package.json
- Create a new tag for the current version if it doesn't exist
- Delete any existing tags with the same version number

The `tests` job remains unchanged, testing the project on different Node.js versions using the Yarn cache.