### PR TITLE
fix(ci): use PAT for semantic-release to bypass branch protection

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,6 +65,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
@@ -82,7 +84,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm semantic-release
     needs: tests


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with `RELEASE_TOKEN` (PAT) in the release job's checkout and environment
- Enables `@semantic-release/git` to push CHANGELOG.md and package.json updates to the protected main branch

## Test plan
- [ ] Merge this PR into main
- [ ] Verify semantic-release runs successfully and pushes version bump commits to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)