### PR TITLE
fix: use conventionalcommits preset for semantic-release

### DIFF
--- a/.releaserc.mjs
+++ b/.releaserc.mjs
@@ -11,8 +11,12 @@ const config = {
   ],
   tagFormat: "${version}",
   plugins: [
-    "@semantic-release/commit-analyzer",                  // Analyze commit messages to determine release type
-    "@semantic-release/release-notes-generator",          // Generate release notes from commit messages
+    ["@semantic-release/commit-analyzer", {                // Analyze commit messages to determine release type
+      preset: "conventionalcommits",                      // Use Conventional Commits preset to recognize feat!: as breaking change
+    }],
+    ["@semantic-release/release-notes-generator", {       // Generate release notes from commit messages
+      preset: "conventionalcommits",                      // Use Conventional Commits preset for release notes
+    }],
     "@semantic-release/changelog",                        // Update CHANGELOG.md with new release notes
     "@semantic-release/github",                           // Publish release notes to GitHub
     "@semantic-release/npm",                              // Publish to npm


### PR DESCRIPTION
## Summary

- Switch `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` to `conventionalcommits` preset
- The default `angular` preset does not recognize `feat!:` as a breaking change
- This fix enables proper major version bumps when using the `!` suffix per the Conventional Commits spec

## Test plan

- [x] Verify `conventional-changelog-conventionalcommits` is already installed as a transitive dependency
- [ ] After merge to main, semantic-release should detect `feat!:` and release 4.0.0