### PR TITLE
ci: add tests-result summary job for branch protection

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -52,6 +52,18 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  tests-result:
+    if: always()
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "Tests failed"
+            exit 1
+          fi
+
   release:
     runs-on: ubuntu-latest
     permissions:
@@ -89,4 +101,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pnpm semantic-release --dry-run
-    needs: tests
+    needs: tests-result

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,18 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  tests-result:
+    if: always()
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "Tests failed"
+            exit 1
+          fi
+
   release:
     runs-on: ubuntu-latest
     permissions:
@@ -87,4 +99,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm semantic-release
-    needs: tests
+    needs: tests-result


### PR DESCRIPTION
## Summary
- Add `tests-result` job to both `develop.yaml` and `main.yaml` workflows
- This job aggregates matrix test results into a single status check
- Updated main branch protection required status check from `tests` to `tests-result`
- Fixes PR #112 being stuck on "Waiting for status to be reported"